### PR TITLE
Change references to "ReVanced" to "RVX"

### DIFF
--- a/lib/services/patcher_api.dart
+++ b/lib/services/patcher_api.dart
@@ -409,7 +409,7 @@ class PatcherAPI {
     final String patchVersion = _managerAPI.patchesVersion!;
     final String prefix = appName.toLowerCase().replaceAll(' ', '-');
     final String newName =
-        '$prefix-revanced_v$version-patches_$patchVersion.apk';
+        '$prefix-rvx_v$version-patches_$patchVersion.apk';
     return newName;
   }
 

--- a/lib/ui/views/installer/installer_viewmodel.dart
+++ b/lib/ui/views/installer/installer_viewmodel.dart
@@ -298,7 +298,7 @@ class InstallerViewModel extends BaseViewModel {
     // Add Info
     final formattedLogs = [
       '- Device Info',
-      'ReVanced Manager: ${info['version']}',
+      'RVX Manager: ${info['version']}',
       'Model: ${info['model']}',
       'Android version: ${info['androidVersion']}',
       'Supported architectures: ${info['supportedArch'].join(", ")}',


### PR DESCRIPTION
This PR makes it so that in exported patch logs it says the patching was done on the RVX Manager instead of the ReVanced Manager.

Additionally, the file name of exported apks will now have "rvx" in their name instead of'revanced". (ex: `youtube-rvx_v19.16.39-patches_v4.10.3.apk`

Although there are dozens of places where "ReVanced" can be converted to "RVX", most are just cosmetic and beyond the scope of this PR. The changes in this PR are useful and not purely cosmetic. 